### PR TITLE
Add support for webpack@5

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Plugin, Compiler } from 'webpack';
+import { WebpackPluginInstance, Compiler } from 'webpack';
 
 export interface SentryCliPluginOptions {
   // general configuration for sentry-cli
@@ -192,7 +192,7 @@ export interface SentryCliPluginOptions {
   };
 }
 
-declare class SentryCliPlugin extends Plugin {
+declare class SentryCliPlugin implements WebpackPluginInstance {
   constructor(options: SentryCliPluginOptions);
 
   apply(compiler: Compiler): void;


### PR DESCRIPTION
webpack@5 have [type definition file](https://github.com/webpack/webpack/blob/master/types.d.ts) and it doesn't export `Plugin` but it seems to use ` WebpackPluginInstance`.